### PR TITLE
Fix license_file entry on recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ about:
   home: https://github.com/eukaryote/pytest-tornasync
   license: MIT
   license_family: MIT
-  license_file: {{ RECIPE_DIR }}/LICENSE
+  license_file: LICENSE
   summary: py.test plugin for testing Python 3.5+ Tornado code
   dev_url: https://github.com/eukaryote/pytest-tornasync
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fix license_file entry on recipe to not use jinja (no longer required).
